### PR TITLE
Initialize accounts via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,19 @@
 CORE_VARIANT=classic
 INSTALL_FULL_DB=TRUE
 
+# Initial user accounts
+ACCOUNT_ADMIN_USER=administrator
+ACCOUNT_ADMIN_PASS=administrator
+
+ACCOUNT_GM_USER=gamemaster
+ACCOUNT_GM_PASS=gamemaster
+
+ACCOUNT_MOD_USER=moderator
+ACCOUNT_MOD_PASS=moderator
+
+ACCOUNT_PLAYER_USER=player
+ACCOUNT_PLAYER_PASS=player
+
 # Database defaults (everything on the same server)
 DB_HOST=database
 DB_PORT=3306

--- a/realmd/Dockerfile
+++ b/realmd/Dockerfile
@@ -25,11 +25,13 @@ ARG CMANGOS_CORE
 ENV CMANGOS_CORE=$CMANGOS_CORE
 
 RUN apt update; \
-	apt install -y \
+	apt install -y --no-install-recommends \
 		mariadb-client \
 		libmariadb3 \
 		wget \
 		unzip \
+		php-cli \
+		php-gmp \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -41,6 +43,8 @@ VOLUME [ "/opt/cmangos/etc" ]
 COPY 00_init.sh /00_init.sh
 COPY wait-for-it.sh /wait-for-it.sh
 RUN chmod +x /00_init.sh && chmod +x /wait-for-it.sh
+
+COPY account-create.php /account-create.php
 
 # Add Tini
 ENV TINI_VERSION v0.19.0

--- a/realmd/account-create.php
+++ b/realmd/account-create.php
@@ -1,0 +1,50 @@
+<?php
+// https://github.com/TrinityCore/TrinityCore/issues/25157
+
+// Credit: https://gist.github.com/Treeston/db44f23503ae9f1542de31cb8d66781e
+function calculateSRP6Verifier($username, $password, $salt)
+{
+    // algorithm constants
+    $g = gmp_init(7);
+    $N = gmp_init('894B645E89E1535BBDAD5B8B290650530801B18EBFBF5E8FAB3C82872A3E9BB7', 16);
+
+    // calculate first hash
+    $h1 = sha1(strtoupper($username . ':' . $password), TRUE);
+
+    // calculate second hash
+	$h2 = sha1(strrev($salt) . $h1, TRUE);
+
+    // convert to integer (little-endian)
+    $h2 = gmp_import($h2, 1, GMP_LSW_FIRST);
+
+    // g^h2 mod N
+    $verifier = gmp_powm($g, $h2, $N);
+
+    // convert back to a byte array (little-endian)
+    $verifier = gmp_export($verifier, 1, GMP_LSW_FIRST);
+
+    // pad to 32 bytes, remember that zeros go on the end in little-endian!
+    $verifier = str_pad($verifier, 32, chr(0), STR_PAD_RIGHT);
+
+    // done!
+	return strrev($verifier);
+}
+
+// Credit: https://gist.github.com/Treeston/40b99dd71f55d55c68857919088b2e41
+// Returns SRP6 parameters to register this username/password combination with
+function getRegistrationData($username, $password)
+{
+    // generate a random salt
+    $salt = random_bytes(32);
+
+    // calculate verifier using this salt
+    $verifier = calculateSRP6Verifier($username, $password, $salt);
+
+    // done - this is what you put in the account table!
+	$salt = strtoupper(bin2hex($salt));
+	$verifier = strtoupper(bin2hex($verifier));
+
+    return array($salt, $verifier);
+}
+
+echo implode( ' ', getRegistrationData( $_SERVER['argv'][1], $_SERVER['argv'][2] ) );


### PR DESCRIPTION
Not really sure if I want to merge this yet. I like the idea of setting up initial accounts as part of the `realmd` image but, the addition of `php-cli` and the required `php-gmp` extension brings the image size up to 227MB from 175MB (+52MB). I've looked around for an alternative and even tried using [`srptool`](https://manpages.debian.org/testing/gnutls-bin/srptool.1.en.html) to generate the needed salt and verifyer strings that are stored in the database.