### PR TITLE
Use GitHub Actions to build and release container images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,8 +16,10 @@ jobs:
 
     strategy:
       matrix:
-        variant: [ classic, tbc, wotlk ]
-        image: [ extractors, realmd, mangosd ]
+        # variant: [ classic, tbc, wotlk ]
+        # image: [ extractors, realmd, mangosd ]
+        variant: [ classic ]
+        image: [ realmd ]
 
     steps:
       - name: Checkout repository
@@ -51,7 +53,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,85 +6,75 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  builder_base:
 
+  build:
     runs-on: ubuntu-latest
-    # permissions:
-    #   contents: read
-    #   packages: write
-    #   id-token: write
-
-    steps:
-      - name: DEBUG
-        run: echo "docker build cmangos-builder"
-      # - name: Checkout repository
-      #   uses: actions/checkout@v3
-
-      # # Install the cosign tool except on PR
-      # # https://github.com/sigstore/cosign-installer
-      # - name: Install cosign
-      #   if: github.event_name != 'pull_request'
-      #   uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
-      #   with:
-      #     cosign-release: 'v1.11.0'
-
-      # # Workaround: https://github.com/docker/build-push-action/issues/461
-      # - name: Setup Docker buildx
-      #   uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
-
-      # # Login against a Docker registry except on PR
-      # # https://github.com/docker/login-action
-      # - name: Log into registry ${{ env.REGISTRY }}
-      #   if: github.event_name != 'pull_request'
-      #   uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
-      #   with:
-      #     registry: ${{ env.REGISTRY }}
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-
-      # # Extract metadata (tags, labels) for Docker
-      # # https://github.com/docker/metadata-action
-      # - name: Extract Docker metadata
-      #   id: meta
-      #   uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-      #   with:
-      #     images: ${{ env.REGISTRY }}/cmangos-builder
-
-      # # Build and push Docker image with Buildx (don't push on PR)
-      # # https://github.com/docker/build-push-action
-      # - name: Build and push Docker image
-      #   id: build-and-push
-      #   uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
-      #   with:
-      #     context: ./builder
-      #     push: ${{ github.event_name != 'pull_request' }}
-      #     tags: ${{ steps.meta.outputs.tags }}
-      #     labels: ${{ steps.meta.outputs.labels }}
-      #     cache-from: type=gha
-      #     cache-to: type=gha,mode=max
-
-      # # Sign the resulting Docker image digest except on PRs.
-      # # This will only write to the public Rekor transparency log when the Docker
-      # # repository is public to avoid leaking data.  If you would like to publish
-      # # transparency data even for private images, pass --force to cosign below.
-      # # https://github.com/sigstore/cosign
-      # - name: Sign the published Docker image
-      #   if: ${{ github.event_name != 'pull_request' }}
-      #   env:
-      #     COSIGN_EXPERIMENTAL: "true"
-      #   # This step uses the identity token to provision an ephemeral certificate
-      #   # against the sigstore community Fulcio instance.
-      #   run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
-
-  build_images:
-    runs-on: ubuntu-latest
-    needs: [builder_base]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
 
     strategy:
       matrix:
         variant: [ classic, tbc, wotlk ]
-        image: [ extractors, relamd, mangosd ]
+        image: [ extractors, realmd, mangosd ]
 
     steps:
-      - name: DEBUG
-        run: echo "docker build cmangos-${{ matrix.image }}-${{ matrix.variant }}"
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        with:
+          cosign-release: 'v1.11.0'
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: ./${{ matrix.image }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,10 @@
 name: Build and Release Container Images
 
-on: push
+on:
+  schedule:
+    - cron: '0 0 * * 0' # At 00:00 on Sunday.
+  push:
+    branches: [ "master" ]
 
 env:
   REGISTRY: ghcr.io
@@ -18,10 +22,8 @@ jobs:
 
     strategy:
       matrix:
-        # variant: [ classic, tbc, wotlk ]
-        # image: [ extractors, realmd, mangosd ]
-        variant: [ classic ]
-        image: [ realmd ]
+        variant: [ classic, tbc, wotlk ]
+        image: [ extractors, realmd, mangosd ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.image }}-${{ matrix.variant }}
+            ${{ env.REGISTRY }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.image }}-${{ matrix.variant }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,74 +4,87 @@ on: push
 
 env:
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  builder_base:
 
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
+    # permissions:
+    #   contents: read
+    #   packages: write
+    #   id-token: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: DEBUG
+        run: echo "docker build cmangos-builder"
+      # - name: Checkout repository
+      #   uses: actions/checkout@v3
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
-        with:
-          cosign-release: 'v1.11.0'
+      # # Install the cosign tool except on PR
+      # # https://github.com/sigstore/cosign-installer
+      # - name: Install cosign
+      #   if: github.event_name != 'pull_request'
+      #   uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+      #   with:
+      #     cosign-release: 'v1.11.0'
 
-      # Workaround: https://github.com/docker/build-push-action/issues/461
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+      # # Workaround: https://github.com/docker/build-push-action/issues/461
+      # - name: Setup Docker buildx
+      #   uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
 
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # # Login against a Docker registry except on PR
+      # # https://github.com/docker/login-action
+      # - name: Log into registry ${{ env.REGISTRY }}
+      #   if: github.event_name != 'pull_request'
+      #   uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+      #   with:
+      #     registry: ${{ env.REGISTRY }}
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # # Extract metadata (tags, labels) for Docker
+      # # https://github.com/docker/metadata-action
+      # - name: Extract Docker metadata
+      #   id: meta
+      #   uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      #   with:
+      #     images: ${{ env.REGISTRY }}/cmangos-builder
 
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
-        with:
-          context: ./builder
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # # Build and push Docker image with Buildx (don't push on PR)
+      # # https://github.com/docker/build-push-action
+      # - name: Build and push Docker image
+      #   id: build-and-push
+      #   uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+      #   with:
+      #     context: ./builder
+      #     push: ${{ github.event_name != 'pull_request' }}
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     labels: ${{ steps.meta.outputs.labels }}
+      #     cache-from: type=gha
+      #     cache-to: type=gha,mode=max
 
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+      # # Sign the resulting Docker image digest except on PRs.
+      # # This will only write to the public Rekor transparency log when the Docker
+      # # repository is public to avoid leaking data.  If you would like to publish
+      # # transparency data even for private images, pass --force to cosign below.
+      # # https://github.com/sigstore/cosign
+      # - name: Sign the published Docker image
+      #   if: ${{ github.event_name != 'pull_request' }}
+      #   env:
+      #     COSIGN_EXPERIMENTAL: "true"
+      #   # This step uses the identity token to provision an ephemeral certificate
+      #   # against the sigstore community Fulcio instance.
+      #   run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+
+  build_images:
+    runs-on: ubuntu-latest
+    needs: [builder_base]
+
+    strategy:
+      matrix:
+        variant: [ classic, tbc, wotlk ]
+        image: [ extractors, relamd, mangosd ]
+
+    steps:
+      - name: DEBUG
+        run: echo "docker build cmangos-${{ matrix.image }}-${{ matrix.variant }}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,8 @@ on: push
 
 env:
   REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
 
@@ -53,7 +55,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,9 +55,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.image }}-${{ matrix.variant }}
-            ${{ env.REGISTRY }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,77 @@
+name: Build and Release Container Images
+
+on: push
+
+env:
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        with:
+          cosign-release: 'v1.11.0'
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: ./builder
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Using the cmangos-extractors-variant container of your chosen core variant, extr
 docker run \
 	-v "/path/to/WoW/client:/client" \
 	-v "/home/$USER/cmangos-docker/extracted-data:/maps" \
-	ghcr.io/jrtashjian/cmangos-extractors-classic
+	ghcr.io/jrtashjian/cmangos-docker/extractors-classic
 ```
 
 ## Credits

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,5 +1,7 @@
 FROM buildpack-deps:stable
-LABEL org.opencontainers.image.source https://github.com/jrtashjian/cmangos-docker
+LABEL org.opencontainers.image.title builder-base
+LABEL org.opencontainers.image.description Base image for building CMaNGOS
+LABEL org.opencontainers.image.source https://github.com/jrtashjian/cmangos-docker/builder
 LABEL org.opencontainers.image.authors jrtashjian
 LABEL org.opencontainers.image.licenses GPL-2.0-only
 

--- a/builder/build-and-release.sh
+++ b/builder/build-and-release.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build --no-cache -t "ghcr.io/jrtashjian/cmangos-docker/builder-base:latest" .
+docker push "ghcr.io/jrtashjian/cmangos-docker/builder-base:latest"

--- a/docker-compose.classic.yml
+++ b/docker-compose.classic.yml
@@ -13,7 +13,7 @@ services:
       - "./data/database:/var/lib/mysql"
 
   realmd:
-    image: ghcr.io/jrtashjian/cmangos-realmd-classic:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/realmd-classic:latest
     depends_on:
       - database
     environment:
@@ -30,7 +30,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
 
   mangosd:
-    image: ghcr.io/jrtashjian/cmangos-mangosd-classic:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-classic:latest
     depends_on:
       - database
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,7 +18,7 @@ services:
       dockerfile: Dockerfile
       args:
         CMANGOS_CORE: ${CORE_VARIANT}
-    image: ghcr.io/jrtashjian/cmangos-realmd-${CORE_VARIANT}:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/realmd-${CORE_VARIANT}:latest
     depends_on:
       - database
     environment:
@@ -39,7 +39,7 @@ services:
       dockerfile: Dockerfile
       args:
         CMANGOS_CORE: ${CORE_VARIANT}
-    image: ghcr.io/jrtashjian/cmangos-mangosd-${CORE_VARIANT}:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-${CORE_VARIANT}:latest
     depends_on:
       - database
       - realmd

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,7 +13,7 @@ services:
       - "./data/database:/var/lib/mysql"
 
   realmd:
-    image: ghcr.io/jrtashjian/cmangos-realmd-${CORE_VARIANT}:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/realmd-${CORE_VARIANT}:latest
     depends_on:
       - database
     env_file: .env
@@ -24,7 +24,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
 
   mangosd:
-    image: ghcr.io/jrtashjian/cmangos-mangosd-${CORE_VARIANT}:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-${CORE_VARIANT}:latest
     depends_on:
       - database
     env_file: .env

--- a/docker-compose.multi-world.yml
+++ b/docker-compose.multi-world.yml
@@ -13,7 +13,7 @@ services:
       - "./data/database:/var/lib/mysql"
 
   realmd:
-    image: ghcr.io/jrtashjian/cmangos-realmd-${CORE_VARIANT}:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/realmd-${CORE_VARIANT}:latest
     depends_on:
       - database
     env_file: .env
@@ -24,7 +24,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
 
   mangosd_one:
-    image: ghcr.io/jrtashjian/cmangos-mangosd-${CORE_VARIANT}:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-${CORE_VARIANT}:latest
     depends_on:
       - database
     env_file: .env
@@ -44,7 +44,7 @@ services:
       - "./extracted-data:/opt/cmangos-data:ro"
 
   mangosd_two:
-    image: ghcr.io/jrtashjian/cmangos-mangosd-${CORE_VARIANT}:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-${CORE_VARIANT}:latest
     depends_on:
       - database
     env_file: .env

--- a/docker-compose.tbc.yml
+++ b/docker-compose.tbc.yml
@@ -13,7 +13,7 @@ services:
       - "./data/database:/var/lib/mysql"
 
   realmd:
-    image: ghcr.io/jrtashjian/cmangos-realmd-tbc:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/realmd-tbc:latest
     depends_on:
       - database
     environment:
@@ -30,7 +30,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
 
   mangosd:
-    image: ghcr.io/jrtashjian/cmangos-mangosd-tbc:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-tbc:latest
     depends_on:
       - database
     environment:

--- a/docker-compose.wotlk.yml
+++ b/docker-compose.wotlk.yml
@@ -13,7 +13,7 @@ services:
       - "./data/database:/var/lib/mysql"
 
   realmd:
-    image: ghcr.io/jrtashjian/cmangos-realmd-wotlk:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/realmd-wotlk:latest
     depends_on:
       - database
     environment:
@@ -30,7 +30,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
 
   mangosd:
-    image: ghcr.io/jrtashjian/cmangos-mangosd-wotlk:latest
+    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-wotlk:latest
     depends_on:
       - database
     environment:

--- a/extractors/Dockerfile
+++ b/extractors/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/jrtashjian/cmangos-builder:latest as builder
+FROM ghcr.io/jrtashjian/cmangos-docker/builder-base:latest as builder
 
 ARG CMANGOS_CORE=classic
 
@@ -13,7 +13,7 @@ RUN mkdir -p /opt/src/cmangos/build && \
 RUN rm -rfv /opt/src
 
 FROM bitnami/minideb:latest
-LABEL org.opencontainers.image.title cmangos-extractors-${CMANGOS_CORE}
+LABEL org.opencontainers.image.title extractors-${CMANGOS_CORE}
 LABEL org.opencontainers.image.description Containerized CMaNGOS Extractors
 LABEL org.opencontainers.image.source https://github.com/jrtashjian/cmangos-docker/extractors
 LABEL org.opencontainers.image.authors jrtashjian

--- a/extractors/Dockerfile
+++ b/extractors/Dockerfile
@@ -13,7 +13,9 @@ RUN mkdir -p /opt/src/cmangos/build && \
 RUN rm -rfv /opt/src
 
 FROM bitnami/minideb:latest
-LABEL org.opencontainers.image.source https://github.com/jrtashjian/cmangos-docker
+LABEL org.opencontainers.image.title cmangos-extractors-${CMANGOS_CORE}
+LABEL org.opencontainers.image.description Containerized CMaNGOS Extractors
+LABEL org.opencontainers.image.source https://github.com/jrtashjian/cmangos-docker/extractors
 LABEL org.opencontainers.image.authors jrtashjian
 LABEL org.opencontainers.image.licenses GPL-2.0-only
 

--- a/mangosd/Dockerfile
+++ b/mangosd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/jrtashjian/cmangos-builder:latest as builder
+FROM ghcr.io/jrtashjian/cmangos-docker/builder-base:latest as builder
 
 ARG CMANGOS_CORE=classic
 ARG BUILD_PLAYERBOT=ON
@@ -23,7 +23,7 @@ RUN mkdir -p /opt/cmangos/sql && \
 RUN rm -rfv /opt/src
 
 FROM bitnami/minideb:latest
-LABEL org.opencontainers.image.title cmangos-mangosd-${CMANGOS_CORE}
+LABEL org.opencontainers.image.title mangosd-${CMANGOS_CORE}
 LABEL org.opencontainers.image.description Containerized CMaNGOS Game Server
 LABEL org.opencontainers.image.source https://github.com/jrtashjian/cmangos-docker/mangosd
 LABEL org.opencontainers.image.authors jrtashjian

--- a/mangosd/Dockerfile
+++ b/mangosd/Dockerfile
@@ -23,7 +23,9 @@ RUN mkdir -p /opt/cmangos/sql && \
 RUN rm -rfv /opt/src
 
 FROM bitnami/minideb:latest
-LABEL org.opencontainers.image.source https://github.com/jrtashjian/cmangos-docker
+LABEL org.opencontainers.image.title cmangos-mangosd-${CMANGOS_CORE}
+LABEL org.opencontainers.image.description Containerized CMaNGOS Game Server
+LABEL org.opencontainers.image.source https://github.com/jrtashjian/cmangos-docker/mangosd
 LABEL org.opencontainers.image.authors jrtashjian
 LABEL org.opencontainers.image.licenses GPL-2.0-only
 

--- a/realmd/Dockerfile
+++ b/realmd/Dockerfile
@@ -17,7 +17,9 @@ RUN mkdir -p /opt/cmangos/sql && cp /opt/src/cmangos/sql/base/realmd.sql /opt/cm
 RUN rm -rfv /opt/src
 
 FROM bitnami/minideb:latest
-LABEL org.opencontainers.image.source https://github.com/jrtashjian/cmangos-docker
+LABEL org.opencontainers.image.title cmangos-realmd-${CMANGOS_CORE}
+LABEL org.opencontainers.image.description Containerized CMaNGOS Login Server
+LABEL org.opencontainers.image.source https://github.com/jrtashjian/cmangos-docker/realmd
 LABEL org.opencontainers.image.authors jrtashjian
 LABEL org.opencontainers.image.licenses GPL-2.0-only
 

--- a/realmd/Dockerfile
+++ b/realmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/jrtashjian/cmangos-builder:latest as builder
+FROM ghcr.io/jrtashjian/cmangos-docker/builder-base:latest as builder
 
 ARG CMANGOS_CORE=classic
 
@@ -17,7 +17,7 @@ RUN mkdir -p /opt/cmangos/sql && cp /opt/src/cmangos/sql/base/realmd.sql /opt/cm
 RUN rm -rfv /opt/src
 
 FROM bitnami/minideb:latest
-LABEL org.opencontainers.image.title cmangos-realmd-${CMANGOS_CORE}
+LABEL org.opencontainers.image.title realmd-${CMANGOS_CORE}
 LABEL org.opencontainers.image.description Containerized CMaNGOS Login Server
 LABEL org.opencontainers.image.source https://github.com/jrtashjian/cmangos-docker/realmd
 LABEL org.opencontainers.image.authors jrtashjian


### PR DESCRIPTION
Add a GitHub Action to build and publish container images as a GitHub Package. This seems to require a change to how the images were named:

Before:
```
ghcr.io/jrtashjian/cmangos-${realmd,mangosd,extractors}-${classic,tbc,wotlk}
```

After:
```
ghcr.io/jrtashjian/cmangos-docker/${realmd,mangosd,extractors}-${classic,tbc,wotlk}
```

Container images will be built once a week automatically (on Sunday) and any pushes to the `master` branch.