### PR TITLE
Remove cmangos-docker from image name

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,7 +68,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@v3
         with:
           context: ./${{ matrix.image }}
           build-args: CMANGOS_CORE=${{ matrix.variant }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,8 +13,6 @@ on: push
 
 env:
   REGISTRY: ghcr.io
-  # # github.repository as <account>/<repo>
-  # IMAGE_NAME: ${{ github.repository }}
 
 jobs:
 
@@ -37,19 +35,19 @@ jobs:
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@v2
         with:
           cosign-release: 'v1.11.0'
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@v2
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
@@ -62,7 +60,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/jrtashjian/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -72,7 +70,7 @@ jobs:
         with:
           context: ./${{ matrix.image }}
           build-args: CMANGOS_CORE=${{ matrix.variant }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true # ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -82,7 +80,7 @@ jobs:
       # transparency data even for private images, pass --force to cosign below.
       # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
+        # if: ${{ github.event_name != 'pull_request' }}
         env:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,10 +18,10 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
+    # permissions:
+    #   contents: read
+    #   packages: write
+    #   id-token: write
 
     strategy:
       matrix:
@@ -71,7 +71,7 @@ jobs:
           context: ./${{ matrix.image }}
           build-args: CMANGOS_CORE=${{ matrix.variant }}
           push: true # ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}:latest
           # tags: ${{ steps.meta.outputs.tags }}
           # labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,10 +18,10 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    # permissions:
-    #   contents: read
-    #   packages: write
-    #   id-token: write
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
 
     strategy:
       matrix:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,10 +20,10 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    # permissions:
-    #   contents: read
-    #   packages: write
-    #   id-token: write
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
 
     strategy:
       matrix:
@@ -38,7 +38,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        uses: sigstore/cosign-installer@v2
         with:
           cosign-release: 'v1.11.0'
 
@@ -50,7 +50,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -60,7 +60,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/jrtashjian/cmangos-${{ matrix.image }}-${{ matrix.variant }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,13 +32,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        # if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v2
-        with:
-          cosign-release: 'v1.11.0'
+      # # Install the cosign tool except on PR
+      # # https://github.com/sigstore/cosign-installer
+      # - name: Install cosign
+      #   # if: github.event_name != 'pull_request'
+      #   uses: sigstore/cosign-installer@v2
+      #   with:
+      #     cosign-release: 'v1.11.0'
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
@@ -54,13 +54,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+      # # Extract metadata (tags, labels) for Docker
+      # # https://github.com/docker/metadata-action
+      # - name: Extract Docker metadata
+      #   id: meta
+      #   uses: docker/metadata-action@v4
+      #   with:
+      #     images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -71,18 +71,19 @@ jobs:
           context: ./${{ matrix.image }}
           build-args: CMANGOS_CORE=${{ matrix.variant }}
           push: true # ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+          # tags: ${{ steps.meta.outputs.tags }}
+          # labels: ${{ steps.meta.outputs.labels }}
 
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        # if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+      # # Sign the resulting Docker image digest except on PRs.
+      # # This will only write to the public Rekor transparency log when the Docker
+      # # repository is public to avoid leaking data.  If you would like to publish
+      # # transparency data even for private images, pass --force to cosign below.
+      # # https://github.com/sigstore/cosign
+      # - name: Sign the published Docker image
+      #   # if: ${{ github.event_name != 'pull_request' }}
+      #   env:
+      #     COSIGN_EXPERIMENTAL: "true"
+      #   # This step uses the identity token to provision an ephemeral certificate
+      #   # against the sigstore community Fulcio instance.
+      #   run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,20 +1,20 @@
 name: Build and Release Container Images
 
-on:
-  workflow_dispatch: # Allow manual trigger.
-  schedule:
-    - cron: '0 0 * * 0' # At 00:00 on Sunday.
-  push:
-    branches: [ "master" ]
-    paths:
-      - 'extractors/**'
-      - 'mangosd/**'
-      - 'realmd/**'
+on: push
+  # workflow_dispatch: # Allow manual trigger.
+  # schedule:
+  #   - cron: '0 0 * * 0' # At 00:00 on Sunday.
+  # push:
+  #   branches: [ "master" ]
+  #   paths:
+  #     - 'extractors/**'
+  #     - 'mangosd/**'
+  #     - 'realmd/**'
 
 env:
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
+  # # github.repository as <account>/<repo>
+  # IMAGE_NAME: ${{ github.repository }}
 
 jobs:
 
@@ -27,8 +27,8 @@ jobs:
 
     strategy:
       matrix:
-        variant: [ classic, tbc, wotlk ]
-        image: [ extractors, realmd, mangosd ]
+        variant: [ classic ] # [ classic, tbc, wotlk ]
+        image: [ realmd ] # [ extractors, realmd, mangosd ]
 
     steps:
       - name: Checkout repository
@@ -62,7 +62,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.image }}-${{ matrix.variant }}
+          images: |
+            jrtashjian/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+            ${{ env.REGISTRY }}/jrtashjian/cmangos-${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,8 +25,8 @@ jobs:
 
     strategy:
       matrix:
-        variant: [ classic ] # [ classic, tbc, wotlk ]
-        image: [ realmd ] # [ extractors, realmd, mangosd ]
+        variant: [ classic, tbc, wotlk ]
+        image: [ extractors, realmd, mangosd ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,10 +20,10 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
+    # permissions:
+    #   contents: read
+    #   packages: write
+    #   id-token: write
 
     strategy:
       matrix:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,9 +62,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: |
-            jrtashjian/cmangos-${{ matrix.image }}-${{ matrix.variant }}
-            ${{ env.REGISTRY }}/jrtashjian/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+          images: ${{ env.REGISTRY }}/jrtashjian/cmangos-${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,8 +13,6 @@ on: push
 
 env:
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository_owner }}
 
 jobs:
 
@@ -37,7 +35,7 @@ jobs:
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
         with:
           cosign-release: 'v1.11.0'
@@ -49,7 +47,7 @@ jobs:
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         with:
           registry: ${{ env.REGISTRY }}
@@ -62,7 +60,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/test-${{ matrix.image }}-${{ matrix.variant }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/test-${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -72,8 +70,7 @@ jobs:
         with:
           context: ./${{ matrix.image }}
           build-args: CMANGOS_CORE=${{ matrix.variant }}
-          # push: ${{ github.event_name != 'pull_request' }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -83,7 +80,7 @@ jobs:
       # transparency data even for private images, pass --force to cosign below.
       # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
-        # if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,8 @@ on: push
 
 env:
   REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository_owner }}
 
 jobs:
 
@@ -32,58 +34,58 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # # Install the cosign tool except on PR
-      # # https://github.com/sigstore/cosign-installer
-      # - name: Install cosign
-      #   # if: github.event_name != 'pull_request'
-      #   uses: sigstore/cosign-installer@v2
-      #   with:
-      #     cosign-release: 'v1.11.0'
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        # if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        with:
+          cosign-release: 'v1.11.0'
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         # if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # # Extract metadata (tags, labels) for Docker
-      # # https://github.com/docker/metadata-action
-      # - name: Extract Docker metadata
-      #   id: meta
-      #   uses: docker/metadata-action@v4
-      #   with:
-      #     images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/test-${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
           context: ./${{ matrix.image }}
           build-args: CMANGOS_CORE=${{ matrix.variant }}
-          push: true # ${{ github.event_name != 'pull_request' }}
-          tags: ${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}:latest
-          # tags: ${{ steps.meta.outputs.tags }}
-          # labels: ${{ steps.meta.outputs.labels }}
+          # push: ${{ github.event_name != 'pull_request' }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
-      # # Sign the resulting Docker image digest except on PRs.
-      # # This will only write to the public Rekor transparency log when the Docker
-      # # repository is public to avoid leaking data.  If you would like to publish
-      # # transparency data even for private images, pass --force to cosign below.
-      # # https://github.com/sigstore/cosign
-      # - name: Sign the published Docker image
-      #   # if: ${{ github.event_name != 'pull_request' }}
-      #   env:
-      #     COSIGN_EXPERIMENTAL: "true"
-      #   # This step uses the identity token to provision an ephemeral certificate
-      #   # against the sigstore community Fulcio instance.
-      #   run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        # if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -71,7 +71,7 @@ jobs:
           context: ./${{ matrix.image }}
           build-args: CMANGOS_CORE=${{ matrix.variant }}
           push: true # ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}:latest
+          tags: ${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}:latest
           # tags: ${{ steps.meta.outputs.tags }}
           # labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,15 +1,15 @@
 name: Build and Release Container Images
 
-on: push
-  # workflow_dispatch: # Allow manual trigger.
-  # schedule:
-  #   - cron: '0 0 * * 0' # At 00:00 on Sunday.
-  # push:
-  #   branches: [ "master" ]
-  #   paths:
-  #     - 'extractors/**'
-  #     - 'mangosd/**'
-  #     - 'realmd/**'
+on:
+  workflow_dispatch: # Allow manual trigger.
+  schedule:
+    - cron: '0 0 * * 0' # At 00:00 on Sunday.
+  push:
+    branches: [ "master" ]
+    paths:
+      - 'extractors/**'
+      - 'mangosd/**'
+      - 'realmd/**'
 
 env:
   REGISTRY: ghcr.io
@@ -60,7 +60,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/test-${{ matrix.image }}-${{ matrix.variant }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/cmangos-${{ matrix.image }}-${{ matrix.variant }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/build-and-release.sh
+++ b/build-and-release.sh
@@ -5,7 +5,7 @@ images=(extractors realmd mangosd)
 
 for variant in "${variants[@]}"; do
 	for image in "${images[@]}"; do
-		docker build --no-cache -t "ghcr.io/jrtashjian/cmangos-docker/$image-$variant:master" ./$image --build-arg CMANGOS_CORE=$variant
-		docker push "ghcr.io/jrtashjian/cmangos-docker/$image-$variant:master"
+		docker build --no-cache -t "ghcr.io/jrtashjian/cmangos-$image-$variant:latest" ./$image --build-arg CMANGOS_CORE=$variant
+		docker push "ghcr.io/jrtashjian/cmangos-$image-$variant:latest"
 	done
 done

--- a/builder/build-and-release.sh
+++ b/builder/build-and-release.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker build --no-cache -t "ghcr.io/jrtashjian/cmangos-docker/builder-base:latest" .
-docker push "ghcr.io/jrtashjian/cmangos-docker/builder-base:latest"
+docker build --no-cache -t "ghcr.io/jrtashjian/cmangos-builder-base:latest" .
+docker push "ghcr.io/jrtashjian/cmangos-builder-base:latest"

--- a/docker-compose.classic.yml
+++ b/docker-compose.classic.yml
@@ -13,7 +13,7 @@ services:
       - "./data/database:/var/lib/mysql"
 
   realmd:
-    image: ghcr.io/jrtashjian/cmangos-docker/realmd-classic:master
+    image: ghcr.io/jrtashjian/cmangos-realmd-classic:master
     depends_on:
       - database
     environment:
@@ -30,7 +30,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
 
   mangosd:
-    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-classic:master
+    image: ghcr.io/jrtashjian/cmangos-mangosd-classic:master
     depends_on:
       - database
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,7 +18,7 @@ services:
       dockerfile: Dockerfile
       args:
         CMANGOS_CORE: ${CORE_VARIANT}
-    image: ghcr.io/jrtashjian/cmangos-docker/realmd-${CORE_VARIANT}:master
+    image: ghcr.io/jrtashjian/cmangos-realmd-${CORE_VARIANT}:master
     depends_on:
       - database
     environment:
@@ -39,7 +39,7 @@ services:
       dockerfile: Dockerfile
       args:
         CMANGOS_CORE: ${CORE_VARIANT}
-    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-${CORE_VARIANT}:master
+    image: ghcr.io/jrtashjian/cmangos-mangosd-${CORE_VARIANT}:master
     depends_on:
       - database
       - realmd

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,7 +13,7 @@ services:
       - "./data/database:/var/lib/mysql"
 
   realmd:
-    image: ghcr.io/jrtashjian/cmangos-docker/realmd-${CORE_VARIANT}:master
+    image: ghcr.io/jrtashjian/cmangos-realmd-${CORE_VARIANT}:master
     depends_on:
       - database
     env_file: .env
@@ -24,7 +24,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
 
   mangosd:
-    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-${CORE_VARIANT}:master
+    image: ghcr.io/jrtashjian/cmangos-mangosd-${CORE_VARIANT}:master
     depends_on:
       - database
     env_file: .env

--- a/docker-compose.multi-world.yml
+++ b/docker-compose.multi-world.yml
@@ -13,7 +13,7 @@ services:
       - "./data/database:/var/lib/mysql"
 
   realmd:
-    image: ghcr.io/jrtashjian/cmangos-docker/realmd-${CORE_VARIANT}:master
+    image: ghcr.io/jrtashjian/cmangos-realmd-${CORE_VARIANT}:master
     depends_on:
       - database
     env_file: .env
@@ -24,7 +24,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
 
   mangosd_one:
-    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-${CORE_VARIANT}:master
+    image: ghcr.io/jrtashjian/cmangos-mangosd-${CORE_VARIANT}:master
     depends_on:
       - database
     env_file: .env
@@ -44,7 +44,7 @@ services:
       - "./extracted-data:/opt/cmangos-data:ro"
 
   mangosd_two:
-    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-${CORE_VARIANT}:master
+    image: ghcr.io/jrtashjian/cmangos-mangosd-${CORE_VARIANT}:master
     depends_on:
       - database
     env_file: .env

--- a/docker-compose.tbc.yml
+++ b/docker-compose.tbc.yml
@@ -13,7 +13,7 @@ services:
       - "./data/database:/var/lib/mysql"
 
   realmd:
-    image: ghcr.io/jrtashjian/cmangos-docker/realmd-tbc:master
+    image: ghcr.io/jrtashjian/cmangos-realmd-tbc:master
     depends_on:
       - database
     environment:
@@ -30,7 +30,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
 
   mangosd:
-    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-tbc:master
+    image: ghcr.io/jrtashjian/cmangos-mangosd-tbc:master
     depends_on:
       - database
     environment:

--- a/docker-compose.wotlk.yml
+++ b/docker-compose.wotlk.yml
@@ -13,7 +13,7 @@ services:
       - "./data/database:/var/lib/mysql"
 
   realmd:
-    image: ghcr.io/jrtashjian/cmangos-docker/realmd-wotlk:master
+    image: ghcr.io/jrtashjian/cmangos-realmd-wotlk:master
     depends_on:
       - database
     environment:
@@ -30,7 +30,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
 
   mangosd:
-    image: ghcr.io/jrtashjian/cmangos-docker/mangosd-wotlk:master
+    image: ghcr.io/jrtashjian/cmangos-mangosd-wotlk:master
     depends_on:
       - database
     environment:

--- a/extractors/Dockerfile
+++ b/extractors/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/jrtashjian/cmangos-docker/builder-base:latest as builder
+FROM ghcr.io/jrtashjian/cmangos-builder-base:latest as builder
 
 ARG CMANGOS_CORE=classic
 

--- a/mangosd/Dockerfile
+++ b/mangosd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/jrtashjian/cmangos-docker/builder-base:latest as builder
+FROM ghcr.io/jrtashjian/cmangos-builder-base:latest as builder
 
 ARG CMANGOS_CORE=classic
 ARG BUILD_PLAYERBOT=ON

--- a/realmd/Dockerfile
+++ b/realmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/jrtashjian/cmangos-docker/builder-base:latest as builder
+FROM ghcr.io/jrtashjian/cmangos-builder-base:latest as builder
 
 ARG CMANGOS_CORE=classic
 


### PR DESCRIPTION
For some reason I could not figure out why this repo name needed to be included as part of the image name in order for a push from the workflow to succeed.

Turns out I needed to add the repo under "Manage Actions access" in package settings. This PR reverts the image name back to `jrtashjian/cmangos-{{ image }}-{{ variant }}`