### PR TITLE
Build playerbot and ahbot variants

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -46,23 +46,30 @@ jobs:
     strategy:
       matrix:
         include:
-          - build_args: ""
-            image_tag: "latest"
+          # - build_args: ""
+          #   image_tag: "latest"
 
           - build_args: |
               BUILD_PLAYERBOT=ON
               BUILD_AHBOT=ON
             image_tag: "with-playerbot-ahbot"
 
-          - build_args: BUILD_PLAYERBOT=ON
-            image_tag: "with-playerbot"
+          # - build_args: BUILD_PLAYERBOT=ON
+          #   image_tag: "with-playerbot"
 
-          - build_args: BUILD_AHBOT=ON
-            image_tag: "with-ahbot"
-    runs-on: ubuntu-latest
-    steps:
-      - name: DEBUG
-        run: echo "docker build cmangos-mangosd-classic:${{ matrix.image_tag }} \n${{ matrix.build_args }}"
+          # - build_args: BUILD_AHBOT=ON
+          #   image_tag: "with-ahbot"
+    uses: ./.github/workflows/container-build-publish.yml
+    with:
+      core: classic
+      image: ${{ matrix.image }}
+      image_tag: ${{ matrix.image_tag }}
+      build_args: ${{ matrix.build_args }}
+      core_hash: ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}
+    # runs-on: ubuntu-latest
+    # steps:
+    #   - name: DEBUG
+    #     run: echo "docker build cmangos-mangosd-classic:${{ matrix.image_tag }} ${{ matrix.build_args }}"
 
   # build_tbc_realmd:
   #   name: Build TBC ${{ matrix.image }} - ${{ needs.get_latest_cmangos_tbc_hash.outputs.core_hash }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -33,25 +33,25 @@ jobs:
           - image: extractors
             image_tag: latest
 
-          - image: realmd
-            image_tag: latest
+          # - image: realmd
+          #   image_tag: latest
 
-          - image: mangosd
-            image_tag: latest
+          # - image: mangosd
+          #   image_tag: latest
 
-          - image: mangosd
-            image_tag: "with-playerbot-ahbot"
-            build_args: |
-              BUILD_PLAYERBOT=ON
-              BUILD_AHBOT=ON
+          # - image: mangosd
+          #   image_tag: "with-playerbot-ahbot"
+          #   build_args: |
+          #     BUILD_PLAYERBOT=ON
+          #     BUILD_AHBOT=ON
 
-          - image: mangosd
-            image_tag: "with-playerbot"
-            build_args: BUILD_PLAYERBOT=ON
+          # - image: mangosd
+          #   image_tag: "with-playerbot"
+          #   build_args: BUILD_PLAYERBOT=ON
 
-          - image: mangosd
-            image_tag: "with-ahbot"
-            build_args: BUILD_AHBOT=ON
+          # - image: mangosd
+          #   image_tag: "with-ahbot"
+          #   build_args: BUILD_AHBOT=ON
 
     uses: ./.github/workflows/container-build-publish.yml
     with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,11 +1,11 @@
 name: Build and Release Container Images
 
-on: push
-  # workflow_dispatch: # Allow manual trigger.
-  # schedule:
-  #   - cron: '0 7 * * *' # Every day at 7am UTC.
-  # push:
-  #   branches: [ "master" ]
+on:
+  workflow_dispatch: # Allow manual trigger.
+  schedule:
+    - cron: '0 7 * * *' # Every day at 7am UTC.
+  push:
+    branches: [ "master" ]
 
 jobs:
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,11 +1,11 @@
 name: Build and Release Container Images
 
-on:
-  workflow_dispatch: # Allow manual trigger.
-  schedule:
-    - cron: '0 7 * * *' # Every day at 7am UTC.
-  push:
-    branches: [ "master" ]
+on: push
+  # workflow_dispatch: # Allow manual trigger.
+  # schedule:
+  #   - cron: '0 7 * * *' # Every day at 7am UTC.
+  # push:
+  #   branches: [ "master" ]
 
 jobs:
 
@@ -14,48 +14,84 @@ jobs:
     with:
       core: classic
 
-  get_latest_cmangos_tbc_hash:
-    uses: ./.github/workflows/get-cmangos-hash.yml
-    with:
-      core: tbc
+  # get_latest_cmangos_tbc_hash:
+  #   uses: ./.github/workflows/get-cmangos-hash.yml
+  #   with:
+  #     core: tbc
 
-  get_latest_cmangos_wotlk_hash:
-    uses: ./.github/workflows/get-cmangos-hash.yml
-    with:
-      core: wotlk
+  # get_latest_cmangos_wotlk_hash:
+  #   uses: ./.github/workflows/get-cmangos-hash.yml
+  #   with:
+  #     core: wotlk
 
-  build_classic_core:
+  build_classic_realmd:
     name: Build Classic ${{ matrix.image }} - ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}
     needs: get_latest_cmangos_classic_hash
     strategy:
       matrix:
-        image: [ extractors, realmd, mangosd ]
-    uses: ./.github/workflows/container-build-publish.yml
-    with:
-      core: classic
-      image: ${{ matrix.image }}
-      core_hash: ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}
+        image: [ extractors, realmd ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: DEBUG
+        run: echo "docker build cmangos-${{ matrix.image }}-classic"
+    # uses: ./.github/workflows/container-build-publish.yml
+    # with:
+    #   core: classic
+    #   image: ${{ matrix.image }}
+    #   core_hash: ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}
 
-  build_tbc_core:
-    name: Build TBC ${{ matrix.image }} - ${{ needs.get_latest_cmangos_tbc_hash.outputs.core_hash }}
-    needs: get_latest_cmangos_tbc_hash
+  build_classic_mangosd:
+    name: Build Classic ${{ matrix.image }} - ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}
+    needs: get_latest_cmangos_classic_hash
     strategy:
       matrix:
-        image: [ extractors, realmd, mangosd ]
-    uses: ./.github/workflows/container-build-publish.yml
-    with:
-      core: tbc
-      image: ${{ matrix.image }}
-      core_hash: ${{ needs.get_latest_cmangos_tbc_hash.outputs.core_hash }}
+        include:
+          - build_args: ""
+            image_tag: "latest"
 
-  build_wotlk_core:
-    name: Build WotLK ${{ matrix.image }} - ${{ needs.get_latest_cmangos_wotlk_hash.outputs.core_hash }}
-    needs: get_latest_cmangos_wotlk_hash
-    strategy:
-      matrix:
-        image: [ extractors, realmd, mangosd ]
-    uses: ./.github/workflows/container-build-publish.yml
-    with:
-      core: wotlk
-      image: ${{ matrix.image }}
-      core_hash: ${{ needs.get_latest_cmangos_wotlk_hash.outputs.core_hash }}
+          - build_args: |
+              BUILD_PLAYERBOT=ON
+              BUILD_AHBOT=ON
+            image_tag: "with-playerbot-ahbot"
+
+          - build_args: BUILD_PLAYERBOT=ON
+            image_tag: "with-playerbot"
+
+          - build_args: BUILD_AHBOT=ON
+            image_tag: "with-ahbot"
+    runs-on: ubuntu-latest
+    steps:
+      - name: DEBUG
+        run: echo "docker build cmangos-mangosd-classic:${{ matrix.image_tag }} \n${{ matrix.build_args }}"
+
+  # build_tbc_realmd:
+  #   name: Build TBC ${{ matrix.image }} - ${{ needs.get_latest_cmangos_tbc_hash.outputs.core_hash }}
+  #   needs: get_latest_cmangos_tbc_hash
+  #   strategy:
+  #     matrix:
+  #       image: [ extractors, realmd ]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: DEBUG
+  #       run: echo "docker build cmangos-${{ matrix.image }}-tbc"
+  #   # uses: ./.github/workflows/container-build-publish.yml
+  #   # with:
+  #   #   core: tbc
+  #   #   image: ${{ matrix.image }}
+  #   #   core_hash: ${{ needs.get_latest_cmangos_tbc_hash.outputs.core_hash }}
+
+  # build_wotlk_realmd:
+  #   name: Build WotLK ${{ matrix.image }} - ${{ needs.get_latest_cmangos_wotlk_hash.outputs.core_hash }}
+  #   needs: get_latest_cmangos_wotlk_hash
+  #   strategy:
+  #     matrix:
+  #       image: [ extractors, realmd ]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: DEBUG
+  #       run: echo "docker build cmangos-${{ matrix.image }}-wotlk"
+  #   # uses: ./.github/workflows/container-build-publish.yml
+  #   # with:
+  #   #   core: wotlk
+  #   #   image: ${{ matrix.image }}
+    #   core_hash: ${{ needs.get_latest_cmangos_wotlk_hash.outputs.core_hash }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -24,41 +24,35 @@ jobs:
   #   with:
   #     core: wotlk
 
-  build_classic_realmd:
-    name: Build Classic ${{ matrix.image }} - ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}
-    needs: get_latest_cmangos_classic_hash
-    strategy:
-      matrix:
-        image: [ extractors, realmd ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: DEBUG
-        run: echo "docker build cmangos-${{ matrix.image }}-classic"
-    # uses: ./.github/workflows/container-build-publish.yml
-    # with:
-    #   core: classic
-    #   image: ${{ matrix.image }}
-    #   core_hash: ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}
-
-  build_classic_mangosd:
-    name: Build Classic ${{ matrix.image }} - ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}
+  build_classic:
+    name: Build Classic ${{ matrix.image }}:${{ matrix.image_tag }} - ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}
     needs: get_latest_cmangos_classic_hash
     strategy:
       matrix:
         include:
-          # - build_args: ""
-          #   image_tag: "latest"
+          - image: extractors
+            image_tag: latest
 
-          - build_args: |
+          - image: realmd
+            image_tag: latest
+
+          - image: mangosd
+            image_tag: latest
+
+          - image: mangosd
+            image_tag: "with-playerbot-ahbot"
+            build_args: |
               BUILD_PLAYERBOT=ON
               BUILD_AHBOT=ON
-            image_tag: "with-playerbot-ahbot"
 
-          # - build_args: BUILD_PLAYERBOT=ON
-          #   image_tag: "with-playerbot"
+          - image: mangosd
+            image_tag: "with-playerbot"
+            build_args: BUILD_PLAYERBOT=ON
 
-          # - build_args: BUILD_AHBOT=ON
-          #   image_tag: "with-ahbot"
+          - image: mangosd
+            image_tag: "with-ahbot"
+            build_args: BUILD_AHBOT=ON
+
     uses: ./.github/workflows/container-build-publish.yml
     with:
       core: classic
@@ -66,39 +60,3 @@ jobs:
       image_tag: ${{ matrix.image_tag }}
       build_args: ${{ matrix.build_args }}
       core_hash: ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}
-    # runs-on: ubuntu-latest
-    # steps:
-    #   - name: DEBUG
-    #     run: echo "docker build cmangos-mangosd-classic:${{ matrix.image_tag }} ${{ matrix.build_args }}"
-
-  # build_tbc_realmd:
-  #   name: Build TBC ${{ matrix.image }} - ${{ needs.get_latest_cmangos_tbc_hash.outputs.core_hash }}
-  #   needs: get_latest_cmangos_tbc_hash
-  #   strategy:
-  #     matrix:
-  #       image: [ extractors, realmd ]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: DEBUG
-  #       run: echo "docker build cmangos-${{ matrix.image }}-tbc"
-  #   # uses: ./.github/workflows/container-build-publish.yml
-  #   # with:
-  #   #   core: tbc
-  #   #   image: ${{ matrix.image }}
-  #   #   core_hash: ${{ needs.get_latest_cmangos_tbc_hash.outputs.core_hash }}
-
-  # build_wotlk_realmd:
-  #   name: Build WotLK ${{ matrix.image }} - ${{ needs.get_latest_cmangos_wotlk_hash.outputs.core_hash }}
-  #   needs: get_latest_cmangos_wotlk_hash
-  #   strategy:
-  #     matrix:
-  #       image: [ extractors, realmd ]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: DEBUG
-  #       run: echo "docker build cmangos-${{ matrix.image }}-wotlk"
-  #   # uses: ./.github/workflows/container-build-publish.yml
-  #   # with:
-  #   #   core: wotlk
-  #   #   image: ${{ matrix.image }}
-    #   core_hash: ${{ needs.get_latest_cmangos_wotlk_hash.outputs.core_hash }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -62,7 +62,7 @@ jobs:
     uses: ./.github/workflows/container-build-publish.yml
     with:
       core: classic
-      image: ${{ matrix.image }}
+      image: mangosd
       image_tag: ${{ matrix.image_tag }}
       build_args: ${{ matrix.build_args }}
       core_hash: ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -14,15 +14,15 @@ jobs:
     with:
       core: classic
 
-  # get_latest_cmangos_tbc_hash:
-  #   uses: ./.github/workflows/get-cmangos-hash.yml
-  #   with:
-  #     core: tbc
+  get_latest_cmangos_tbc_hash:
+    uses: ./.github/workflows/get-cmangos-hash.yml
+    with:
+      core: tbc
 
-  # get_latest_cmangos_wotlk_hash:
-  #   uses: ./.github/workflows/get-cmangos-hash.yml
-  #   with:
-  #     core: wotlk
+  get_latest_cmangos_wotlk_hash:
+    uses: ./.github/workflows/get-cmangos-hash.yml
+    with:
+      core: wotlk
 
   build_classic:
     name: Build Classic ${{ matrix.image }}:${{ matrix.image_tag }} - ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}
@@ -33,25 +33,25 @@ jobs:
           - image: extractors
             image_tag: latest
 
-          # - image: realmd
-          #   image_tag: latest
+          - image: realmd
+            image_tag: latest
 
-          # - image: mangosd
-          #   image_tag: latest
+          - image: mangosd
+            image_tag: latest
 
-          # - image: mangosd
-          #   image_tag: "with-playerbot-ahbot"
-          #   build_args: |
-          #     BUILD_PLAYERBOT=ON
-          #     BUILD_AHBOT=ON
+          - image: mangosd
+            image_tag: "with-playerbot-ahbot"
+            build_args: |
+              BUILD_PLAYERBOT=ON
+              BUILD_AHBOT=ON
 
-          # - image: mangosd
-          #   image_tag: "with-playerbot"
-          #   build_args: BUILD_PLAYERBOT=ON
+          - image: mangosd
+            image_tag: "with-playerbot"
+            build_args: BUILD_PLAYERBOT=ON
 
-          # - image: mangosd
-          #   image_tag: "with-ahbot"
-          #   build_args: BUILD_AHBOT=ON
+          - image: mangosd
+            image_tag: "with-ahbot"
+            build_args: BUILD_AHBOT=ON
 
     uses: ./.github/workflows/container-build-publish.yml
     with:
@@ -60,3 +60,77 @@ jobs:
       image_tag: ${{ matrix.image_tag }}
       build_args: ${{ matrix.build_args }}
       core_hash: ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}
+
+  build_tbc:
+    name: Build TBC ${{ matrix.image }}:${{ matrix.image_tag }} - ${{ needs.get_latest_cmangos_tbc_hash.outputs.core_hash }}
+    needs: get_latest_cmangos_tbc_hash
+    strategy:
+      matrix:
+        include:
+          - image: extractors
+            image_tag: latest
+
+          - image: realmd
+            image_tag: latest
+
+          - image: mangosd
+            image_tag: latest
+
+          - image: mangosd
+            image_tag: "with-playerbot-ahbot"
+            build_args: |
+              BUILD_PLAYERBOT=ON
+              BUILD_AHBOT=ON
+
+          - image: mangosd
+            image_tag: "with-playerbot"
+            build_args: BUILD_PLAYERBOT=ON
+
+          - image: mangosd
+            image_tag: "with-ahbot"
+            build_args: BUILD_AHBOT=ON
+
+    uses: ./.github/workflows/container-build-publish.yml
+    with:
+      core: tbc
+      image: ${{ matrix.image }}
+      image_tag: ${{ matrix.image_tag }}
+      build_args: ${{ matrix.build_args }}
+      core_hash: ${{ needs.get_latest_cmangos_tbc_hash.outputs.core_hash }}
+
+  build_wotlk:
+    name: Build WotLK ${{ matrix.image }}:${{ matrix.image_tag }} - ${{ needs.get_latest_cmangos_wotlk_hash.outputs.core_hash }}
+    needs: get_latest_cmangos_wotlk_hash
+    strategy:
+      matrix:
+        include:
+          - image: extractors
+            image_tag: latest
+
+          - image: realmd
+            image_tag: latest
+
+          - image: mangosd
+            image_tag: latest
+
+          - image: mangosd
+            image_tag: "with-playerbot-ahbot"
+            build_args: |
+              BUILD_PLAYERBOT=ON
+              BUILD_AHBOT=ON
+
+          - image: mangosd
+            image_tag: "with-playerbot"
+            build_args: BUILD_PLAYERBOT=ON
+
+          - image: mangosd
+            image_tag: "with-ahbot"
+            build_args: BUILD_AHBOT=ON
+
+    uses: ./.github/workflows/container-build-publish.yml
+    with:
+      core: wotlk
+      image: ${{ matrix.image }}
+      image_tag: ${{ matrix.image_tag }}
+      build_args: ${{ matrix.build_args }}
+      core_hash: ${{ needs.get_latest_cmangos_wotlk_hash.outputs.core_hash }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -56,7 +56,7 @@ jobs:
     uses: ./.github/workflows/container-build-publish.yml
     with:
       core: classic
-      image: mangosd
+      image: ${{ matrix.image }}
       image_tag: ${{ matrix.image_tag }}
       build_args: ${{ matrix.build_args }}
       core_hash: ${{ needs.get_latest_cmangos_classic_hash.outputs.core_hash }}

--- a/.github/workflows/container-build-publish.yml
+++ b/.github/workflows/container-build-publish.yml
@@ -12,6 +12,16 @@ on:
         description: Container image to build
         required: true
         type: string
+      image_tag:
+        description: The tag of the image
+        required: false
+        type: string
+        default: latest
+      build_args:
+        description: CMaNGOS build args
+        required: false
+        type: string
+        default: ""
       core_hash:
         description: The commit hash
         required: false
@@ -60,7 +70,7 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ghcr.io/${{ github.repository_owner }}/cmangos-${{ inputs.image }}-${{ inputs.core }}
-          tags: type=raw,value=latest
+          tags: type=raw,value=${{ inputs.image_tag }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -72,6 +82,7 @@ jobs:
           build-args: |
             CMANGOS_CORE=${{ inputs.core }}
             CORE_COMMIT_HASH=${{ inputs.core_hash }}
+            ${{ inputs.build_args }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/container-build-publish.yml
+++ b/.github/workflows/container-build-publish.yml
@@ -49,15 +49,14 @@ jobs:
       #   with:
       #     cosign-release: 'v1.11.0'
 
-      # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+        uses: docker/setup-buildx-action@v2
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ghcr.io
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -67,7 +66,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository_owner }}/cmangos-${{ inputs.image }}-${{ inputs.core }}
           tags: type=raw,value=${{ inputs.image_tag }}
@@ -76,7 +75,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@v3
         with:
           context: ./${{ inputs.image }}
           build-args: |

--- a/.github/workflows/container-build-publish.yml
+++ b/.github/workflows/container-build-publish.yml
@@ -41,14 +41,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # # Install the cosign tool except on PR
-      # # https://github.com/sigstore/cosign-installer
-      # - name: Install cosign
-      #   if: github.event_name != 'pull_request'
-      #   uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
-      #   with:
-      #     cosign-release: 'v1.11.0'
-
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
 
@@ -87,16 +79,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      # # Sign the resulting Docker image digest except on PRs.
-      # # This will only write to the public Rekor transparency log when the Docker
-      # # repository is public to avoid leaking data.  If you would like to publish
-      # # transparency data even for private images, pass --force to cosign below.
-      # # https://github.com/sigstore/cosign
-      # - name: Sign the published Docker image
-      #   if: ${{ github.event_name != 'pull_request' }}
-      #   env:
-      #     COSIGN_EXPERIMENTAL: "true"
-      #   # This step uses the identity token to provision an ephemeral certificate
-      #   # against the sigstore community Fulcio instance.
-      #   run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/container-build-publish.yml
+++ b/.github/workflows/container-build-publish.yml
@@ -41,13 +41,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
-        with:
-          cosign-release: 'v1.11.0'
+      # # Install the cosign tool except on PR
+      # # https://github.com/sigstore/cosign-installer
+      # - name: Install cosign
+      #   if: github.event_name != 'pull_request'
+      #   uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+      #   with:
+      #     cosign-release: 'v1.11.0'
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
@@ -89,15 +89,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+      # # Sign the resulting Docker image digest except on PRs.
+      # # This will only write to the public Rekor transparency log when the Docker
+      # # repository is public to avoid leaking data.  If you would like to publish
+      # # transparency data even for private images, pass --force to cosign below.
+      # # https://github.com/sigstore/cosign
+      # - name: Sign the published Docker image
+      #   if: ${{ github.event_name != 'pull_request' }}
+      #   env:
+      #     COSIGN_EXPERIMENTAL: "true"
+      #   # This step uses the identity token to provision an ephemeral certificate
+      #   # against the sigstore community Fulcio instance.
+      #   run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/build-and-release.sh
+++ b/build-and-release.sh
@@ -1,11 +1,25 @@
 #!/bin/bash
 
 variants=(classic tbc wotlk)
-images=(extractors realmd mangosd)
+images=(extractors realmd)
 
 for variant in "${variants[@]}"; do
 	for image in "${images[@]}"; do
 		docker build --no-cache -t "ghcr.io/jrtashjian/cmangos-$image-$variant:latest" ./$image --build-arg CMANGOS_CORE=$variant
 		docker push "ghcr.io/jrtashjian/cmangos-$image-$variant:latest"
 	done
+done
+
+for variant in "${variants[@]}"; do
+	docker build --no-cache -t "ghcr.io/jrtashjian/cmangos-mangosd-$variant:latest" ./mangosd --build-arg CMANGOS_CORE=$variant
+	docker push "ghcr.io/jrtashjian/cmangos-mangosd-$variant:latest"
+
+	docker build --no-cache -t "ghcr.io/jrtashjian/cmangos-mangosd-$variant:playerbot" ./mangosd --build-arg CMANGOS_CORE=$variant --build-arg BUILD_PLAYERBOT=ON
+	docker push "ghcr.io/jrtashjian/cmangos-mangosd-$variant:playerbot"
+
+	docker build --no-cache -t "ghcr.io/jrtashjian/cmangos-mangosd-$variant:ahbot" ./mangosd --build-arg CMANGOS_CORE=$variant --build-arg BUILD_AHBOT=ON
+	docker push "ghcr.io/jrtashjian/cmangos-mangosd-$variant:ahbot"
+
+	docker build --no-cache -t "ghcr.io/jrtashjian/cmangos-mangosd-$variant:playerbot-ahbot" ./mangosd --build-arg CMANGOS_CORE=$variant --build-arg BUILD_PLAYERBOT=ON --build-arg BUILD_AHBOT=ON
+	docker push "ghcr.io/jrtashjian/cmangos-mangosd-$variant:playerbot-ahbot"
 done

--- a/mangosd/Dockerfile
+++ b/mangosd/Dockerfile
@@ -2,8 +2,8 @@ FROM ghcr.io/jrtashjian/cmangos-builder-base:latest as builder
 
 ARG CMANGOS_CORE=classic
 ARG CORE_COMMIT_HASH=HEAD
-ARG BUILD_PLAYERBOT=ON
-ARG BUILD_AHBOT=ON
+ARG BUILD_PLAYERBOT=OFF
+ARG BUILD_AHBOT=OFF
 ARG BUILD_METRICS=OFF
 
 RUN mkdir -p /opt/src && \


### PR DESCRIPTION
Updating the images so playerbot and ahbot are disabled by default and creating additional images for enabling each module.

- `image:with-playerbot-ahbot`
- `image:with-playerbot`
- `image:with-ahbot`

I was originally not going to do this but I need a quick way to spin up some containers for testing https://github.com/cmangos/issues/issues/3140 with each module ON and OFF.

Excessive? Maybe, but it's fun :smile: